### PR TITLE
List as compatible with gatsby 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "typedoc": "typedoc --options typedoc.config.js"
   },
   "peerDependencies": {
-    "gatsby": "~2.x.x"
+    "gatsby": "~2.x.x || ~3.x.x"
   },
   "dependencies": {
     "tsconfig-paths-webpack-plugin": "^3.2.0"


### PR DESCRIPTION
I've tested your plugin with a Gatsby v3 project and it's working fine.
Currently though it outputs a warning during the build:
```
warn Plugin gatsby-plugin-tsconfig-paths is not compatible with your gatsby version 3.2.1 - It
requires gatsby@~2.x.x
```

This fixes #2 